### PR TITLE
Expose types that are more similar to types required by http-client

### DIFF
--- a/src/Network/Pusher.hs
+++ b/src/Network/Pusher.hs
@@ -92,7 +92,7 @@ import Control.Monad.Trans.Except
   ( ExceptT (ExceptT),
     runExceptT,
   )
-import qualified Data.ByteString.Char8 as BC
+import qualified Data.ByteString as B
 import qualified Data.Text as T
 import Network.Pusher.Data
   ( Credentials (..),
@@ -172,7 +172,7 @@ channels pusher prefixFilter attributes =
 channel ::
   MonadIO m =>
   Pusher ->
-  T.Text ->
+  B.ByteString ->
   -- | Can query user count and also subscription count (if enabled).
   ChannelInfoQuery ->
   m (Either PusherError FullChannelInfo)
@@ -184,7 +184,7 @@ channel pusher chan attributes = liftIO $ runExceptT $ do
   HTTP.get (pusherConnectionManager pusher) requestParams
 
 -- | Get a list of users in a presence channel.
-users :: MonadIO m => Pusher -> T.Text -> m (Either PusherError Users)
+users :: MonadIO m => Pusher -> B.ByteString -> m (Either PusherError Users)
 users pusher chan = liftIO $ runExceptT $ do
   requestParams <-
     liftIO $ Pusher.mkUsersRequest pusher chan <$> getSystemTimeSeconds
@@ -195,8 +195,8 @@ users pusher chan = liftIO $ runExceptT $ do
 --  is correctly encrypted by the corresponding 'AppSecret'.
 parseWebhookPayload ::
   Pusher ->
-  [(BC.ByteString, BC.ByteString)] ->
-  BC.ByteString ->
+  [(B.ByteString, B.ByteString)] ->
+  B.ByteString ->
   Maybe WebhookPayload
 parseWebhookPayload pusher =
   let credentials = pusherCredentials pusher

--- a/src/Network/Pusher/Internal.hs
+++ b/src/Network/Pusher/Internal.hs
@@ -76,56 +76,48 @@ mkChannelsRequest pusher prefixFilter attributes timestamp =
    in mkGetRequest pusher "channels" params timestamp
 
 mkChannelRequest ::
-  Pusher -> T.Text -> ChannelInfoQuery -> Word64 -> RequestParams
+  Pusher -> B.ByteString -> ChannelInfoQuery -> Word64 -> RequestParams
 mkChannelRequest pusher chan attributes timestamp =
   let params = [("info", Just $ encodeUtf8 $ toURLParam attributes)]
       subPath = "channels/" <> chan
    in mkGetRequest pusher subPath params timestamp
 
-mkUsersRequest :: Pusher -> T.Text -> Word64 -> RequestParams
+mkUsersRequest :: Pusher -> B.ByteString -> Word64 -> RequestParams
 mkUsersRequest pusher chan timestamp =
   let subPath = "channels/" <> chan <> "/users"
    in mkGetRequest pusher subPath [] timestamp
 
 mkGetRequest ::
   Pusher ->
-  T.Text ->
+  B.ByteString ->
   Query ->
   Word64 ->
   RequestParams
 mkGetRequest pusher subPath params timestamp =
-  let (ep, fullPath) = mkEndpoint pusher subPath
-      qs = mkQS pusher "GET" fullPath params "" timestamp
-   in RequestParams ep qs
+  let host = pusherHost pusher
+      port = pusherPort pusher
+      path = pusherPath pusher <> subPath
+      qs = mkQS pusher "GET" path params "" timestamp
+   in RequestParams host port path qs
 
 mkPostRequest ::
   Pusher ->
-  T.Text ->
+  B.ByteString ->
   Query ->
   B.ByteString ->
   Word64 ->
   RequestParams
 mkPostRequest pusher subPath params bodyBS timestamp =
-  let (ep, fullPath) = mkEndpoint pusher subPath
-      qs = mkQS pusher "POST" fullPath params bodyBS timestamp
-   in RequestParams ep qs
-
--- | Build a full endpoint from the details in Pusher and the subPath.
-mkEndpoint ::
-  Pusher ->
-  -- | The subpath of the specific request, e.g "events/channel-name".
-  T.Text ->
-  -- | The full endpoint, and just the path component.
-  (T.Text, T.Text)
-mkEndpoint pusher subPath =
-  let fullPath = pusherPath pusher <> subPath
-      endpoint = pusherHost pusher <> fullPath
-   in (endpoint, fullPath)
+  let host = pusherHost pusher
+      port = pusherPort pusher
+      path = pusherPath pusher <> subPath
+      qs = mkQS pusher "POST" path params bodyBS timestamp
+   in RequestParams host port path qs
 
 mkQS ::
   Pusher ->
-  T.Text ->
-  T.Text ->
+  B.ByteString ->
+  B.ByteString ->
   Query ->
   B.ByteString ->
   Word64 ->

--- a/src/Network/Pusher/Internal/Auth.hs
+++ b/src/Network/Pusher/Internal/Auth.hs
@@ -41,8 +41,8 @@ import Network.Pusher.Internal.Util (show')
 makeQS ::
   B.ByteString ->
   B.ByteString ->
-  T.Text ->
-  T.Text ->
+  B.ByteString ->
+  B.ByteString ->
   -- | Any additional parameters.
   Query ->
   B.ByteString ->
@@ -68,7 +68,7 @@ makeQS appKey appSecret method path params body timestamp =
         authSignature appSecret $
           B.intercalate
             "\n"
-            [encodeUtf8 method, encodeUtf8 path, renderQuery False allParams]
+            [method, path, renderQuery False allParams]
    in -- Add the auth string to the list
       ("auth_signature", Just authSig) : allParams
 


### PR DESCRIPTION
This generally means replacing Text with ByteString. ByteString is the right choice here.

Another change was to pass down the components of the URL, rather than building
a URL string, which is then parsed before sending it to http-client.