### PR TITLE
Revert to non-tls by default

### DIFF
--- a/src/Network/Pusher/Internal/HTTP.hs
+++ b/src/Network/Pusher/Internal/HTTP.hs
@@ -82,7 +82,7 @@ mkRequest ::
 mkRequest host port path query =
   HTTP.Client.setQueryString query $
     HTTP.Client.defaultRequest
-      { HTTP.Client.secure = True,
+      { HTTP.Client.secure = False,
         HTTP.Client.host = host,
         HTTP.Client.port = fromIntegral port,
         HTTP.Client.path = path


### PR DESCRIPTION
Secure connections do not work because http-client-tls is not
imported.