### PR TITLE
Revamp the Credentials type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 cabal.sandbox.config
 dist/
 .stack-work/
-example/credentials.yaml
+example/settings.yaml

--- a/example/api/Main.hs
+++ b/example/api/Main.hs
@@ -10,11 +10,11 @@ import qualified Network.Pusher.Protocol as P
 
 main :: IO ()
 main = do
-  eitherCred <- Y.decodeFileEither "../credentials.yaml"
-  case eitherCred of
+  eitherSettings <- Y.decodeFileEither "../settings.yaml"
+  case eitherSettings of
     Left e -> print e
-    Right cred -> do
-      pusher <- P.getPusher cred
+    Right settings -> do
+      pusher <- P.newPusher settings
       demoTrigger pusher
       demoChannels pusher
       demoChannel pusher

--- a/example/credentials.example.yaml
+++ b/example/credentials.example.yaml
@@ -1,4 +1,0 @@
-app-id: <Your app ID>
-app-key: <Your app key>
-app-secret: <Your app secret>
-app-cluster: <Your app cluster>

--- a/example/index.html
+++ b/example/index.html
@@ -13,7 +13,8 @@
 <script src="http://js.pusher.com/2.2/pusher.min.js"></script>
 <script>
   Pusher.log = console.log.bind(console);
-  var pusher = new Pusher("7435d7e5de69a077ebe0", { // TODO: don't hardcode
+  var pusher = new Pusher("ebb0fb32ed472f7e5b06", { // TODO: don't hardcode
+    'cluster': "eu",
     'authEndpoint': "http://0.0.0.0:8000/",
     'authTransport': "jsonp"
   });

--- a/example/settings.example.yaml
+++ b/example/settings.example.yaml
@@ -1,0 +1,5 @@
+app_id: <Your app ID>
+token:
+  key: <Your app key>
+  secret: <Your app secret>
+cluster: <Your app cluster>

--- a/example/webhook/Main.hs
+++ b/example/webhook/Main.hs
@@ -12,11 +12,11 @@ import qualified Snap.Http.Server as Snap
 
 main :: IO ()
 main = do
-  eitherCred <- Y.decodeFileEither "../credentials.yaml"
-  case eitherCred of
+  eitherSettings <- Y.decodeFileEither "../settings.yaml"
+  case eitherSettings of
     Left e -> print e
-    Right cred -> do
-      pusher <- P.getPusher cred
+    Right settings -> do
+      pusher <- P.newPusher settings
       Snap.quickHttpServe $ Snap.method Snap.POST $ webhookHandler pusher
 
 webhookHandler :: P.Pusher -> Snap.Snap ()

--- a/src/Network/Pusher/Internal.hs
+++ b/src/Network/Pusher/Internal.hs
@@ -22,10 +22,7 @@ import qualified Data.Text as T
 import Data.Text.Encoding (encodeUtf8)
 import Data.Word (Word64)
 import Network.HTTP.Types (Query)
-import Network.Pusher.Data
-  ( Credentials (..),
-    Pusher (..),
-  )
+import Network.Pusher.Data (Pusher (..))
 import Network.Pusher.Error (PusherError (..))
 import Network.Pusher.Internal.Auth (makeQS)
 import Network.Pusher.Internal.HTTP
@@ -94,10 +91,10 @@ mkGetRequest ::
   Word64 ->
   RequestParams
 mkGetRequest pusher subPath params timestamp =
-  let host = pusherHost pusher
-      port = pusherPort pusher
-      path = pusherPath pusher <> subPath
-      qs = mkQS pusher "GET" path params "" timestamp
+  let host = pHost pusher
+      port = pPort pusher
+      path = pPath pusher <> subPath
+      qs = makeQS (pToken pusher) "GET" path params "" timestamp
    in RequestParams host port path qs
 
 mkPostRequest ::
@@ -108,20 +105,8 @@ mkPostRequest ::
   Word64 ->
   RequestParams
 mkPostRequest pusher subPath params bodyBS timestamp =
-  let host = pusherHost pusher
-      port = pusherPort pusher
-      path = pusherPath pusher <> subPath
-      qs = mkQS pusher "POST" path params bodyBS timestamp
+  let host = pHost pusher
+      port = pPort pusher
+      path = pPath pusher <> subPath
+      qs = makeQS (pToken pusher) "POST" path params bodyBS timestamp
    in RequestParams host port path qs
-
-mkQS ::
-  Pusher ->
-  B.ByteString ->
-  B.ByteString ->
-  Query ->
-  B.ByteString ->
-  Word64 ->
-  Query
-mkQS pusher =
-  let credentials = pusherCredentials pusher
-   in makeQS (credentialsAppKey credentials) (credentialsAppSecret credentials)

--- a/src/Network/Pusher/Internal/Util.hs
+++ b/src/Network/Pusher/Internal/Util.hs
@@ -1,6 +1,6 @@
 -- |
 -- Module      : Network.Pusher.Internal.Util
--- Description : Various utilty functions
+-- Description : Various utility functions
 -- Copyright   : (c) Will Sewell, 2016
 -- Licence     : MIT
 -- Maintainer  : me@willsewell.com

--- a/test/Auth.hs
+++ b/test/Auth.hs
@@ -1,6 +1,6 @@
 module Auth where
 
-import Network.Pusher (Credentials (..))
+import Network.Pusher (Token (..))
 import Network.Pusher.Internal.Auth
   ( authenticatePresenceWithEncoder,
     authenticatePrivate,
@@ -17,8 +17,7 @@ test = do
     let body =
           "{\"name\":\"foo\",\"channels\":[\"project-3\"],\"data\":\"{\\\"some\\\":\\\"data\\\"}\"}"
      in makeQS
-          (credentialsAppKey credentials)
-          (credentialsAppSecret credentials)
+          token
           "POST"
           "/apps/3/events"
           []
@@ -36,7 +35,7 @@ test = do
     $ it "works"
     $
     -- Data from https://pusher.com/docs/channels/library_auth_reference/auth-signatures#worked-example
-    authenticatePrivate credentials "1234.1234" "private-foobar"
+    authenticatePrivate token "1234.1234" "private-foobar"
       `shouldBe` "278d425bdf160c739803:58df8b0c36d6982b82c3ecf6b4662e34fe8c25bba48f5369f135bf843651c3a4"
   describe "Auth.authenticatePresenceWithEncoder"
     $ it "works for presence channels"
@@ -45,17 +44,15 @@ test = do
     let userData = "{\"user_id\":10,\"user_info\":{\"name\":\"Mr. Pusher\"}}"
      in authenticatePresenceWithEncoder
           (const userData)
-          credentials
+          token
           "1234.1234"
           "presence-foobar"
           ("doesn't matter" :: String)
           `shouldBe` "278d425bdf160c739803:afaed3695da2ffd16931f457e338e6c9f2921fa133ce7dac49f529792be6304c"
 
-credentials :: Credentials
-credentials =
-  Credentials
-    { credentialsAppID = 3,
-      credentialsAppKey = "278d425bdf160c739803",
-      credentialsAppSecret = "7ad3773142a6692b25b8",
-      credentialsCluster = Nothing
+token :: Token
+token =
+  Token
+    { pusherKey = "278d425bdf160c739803",
+      pusherSecret = "7ad3773142a6692b25b8"
     }


### PR DESCRIPTION
Replace Credentials with Settings and Token. The for the user to
Create a Settings with public fields, and then use `newPusher` to
create a Pusher instance (with private fields).

Also provides a `defaultSettings` for convenience (particularly
when more settings are added).

Resolves https://github.com/WillSewell/pusher-http-haskell/issues/71.